### PR TITLE
fix benchmarking tests

### DIFF
--- a/pallets/hmtoken/Cargo.toml
+++ b/pallets/hmtoken/Cargo.toml
@@ -30,6 +30,7 @@ default = ["std"]
 std = [
 	"serde",
 	"codec/std",
+	"frame-benchmarking/std",
 	"frame-support/std",
 	"frame-system/std",
 	"sp-runtime/std",

--- a/pallets/hmtoken/src/mock.rs
+++ b/pallets/hmtoken/src/mock.rs
@@ -1,4 +1,4 @@
-use crate::{Module, Trait};
+use crate::{Module, Trait, WeightInfo};
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, weights::Weight};
 use frame_system as system;
 use sp_core::H256;
@@ -68,11 +68,18 @@ parameter_types! {
 
 }
 
+pub struct MockWeightInfo;
+impl WeightInfo for MockWeightInfo {
+    fn transfer() -> Weight { 0 }
+	fn transfer_bulk(a: u32, ) -> Weight { 0 }
+}
+
 impl Trait for Test {
     type Event = TestEvent;
     type Balance = u128;
     type BulkAccountsLimit = BulkAccountsLimit;
     type BulkBalanceLimit = BulkBalanceLimit;
+    type WeightInfo = MockWeightInfo;
 }
 
 pub type HMToken = Module<Test>;

--- a/pallets/kvstore/Cargo.toml
+++ b/pallets/kvstore/Cargo.toml
@@ -31,6 +31,7 @@ sp-runtime = { default-features = false, version = '2.0.0' }
 default = ['std']
 std = [
     'codec/std',
+    "frame-benchmarking/std",
     'frame-support/std',
     'frame-system/std',
     'sp-std/std',

--- a/pallets/kvstore/src/mock.rs
+++ b/pallets/kvstore/src/mock.rs
@@ -1,4 +1,4 @@
-use crate::{Module, Trait};
+use crate::{Module, Trait, WeightInfo};
 use sp_core::H256;
 use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, weights::Weight};
 use sp_runtime::{
@@ -64,9 +64,15 @@ parameter_types! {
 	pub const StringLimit: usize = 50;
 }
 
+pub struct MockWeightInfo;
+impl WeightInfo for MockWeightInfo {
+    fn set(_: u32, _: u32) -> Weight { 0 }
+}
+
 impl Trait for Test {
 	type Event = TestEvent;
 	type StringLimit = StringLimit;
+	type WeightInfo = MockWeightInfo;
 }
 
 pub type KVStore = Module<Test>;


### PR DESCRIPTION
The pallets were missing the `frame-benchmarking/std` feature flag to build correctly when trying to run benchmark tests.
Also added mock weight impls for the tests.